### PR TITLE
Rails for API applications (rails-api)

### DIFF
--- a/S04E08.md
+++ b/S04E08.md
@@ -6,6 +6,7 @@
 * 16 апреля вышел [ruby-plsql](https://github.com/rsim/ruby-plsql)
 * Вышло расширение к Chrome [CoffeeConsole](http://snook.ca/archives/browsers/coffeeconsole)
 * [mruby](http://matt.aimonetti.net/posts/2012/04/20/mruby-and-mobiruby/) and [MobiRuby](http://mobiruby.org/)
+* [Rails for API applications (rails-api)](http://blog.wyeworks.com/2012/4/20/rails-for-api-applications-rails-api-released)
 * 19 и 20 мая [Brainwashing](http://brainwashing.pro/rails)
 
 # Обсуждение


### PR DESCRIPTION
Rails for API applications (rails-api)

http://blog.wyeworks.com/2012/4/20/rails-for-api-applications-rails-api-released

https://github.com/spastorino/rails-api
